### PR TITLE
Deprecate in favor of mkdirp-bluebird

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # bluebird-mkdirp
 
+## deprecation warning
+
+**WARNING**
+
+[![npm version](https://img.shields.io/badge/NPM-deprecated-red.svg)](https://github.com/maxkoryukov/mkdirp-bluebird)
+
+This repository and corresponding NPM package are deprecated in favor of [**mkdirp-bluebird**](https://www.npmjs.com/package/mkdirp-bluebird).
+
+Useful links:
+
+1. [NPM package](https://www.npmjs.com/package/mkdirp-bluebird):
+    * `npm install -S mkdirp-bluebird`
+2. GitHub, `mkdirp-bluebird`:
+    * [v2 on master branch](https://github.com/maxkoryukov/mkdirp-bluebird)
+
+----
+
 promisify'd version of mkdirp using bluebird and mkdirp as `peerDependencies`.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **WARNING**
 
-[![npm version](https://img.shields.io/badge/NPM-deprecated-red.svg)](https://github.com/maxkoryukov/mkdirp-bluebird)
+[![npm version](https://img.shields.io/badge/NPM-deprecated-red.svg)](https://github.com/maxkoryukov/mkdirp-bluebird/issues/2)
 
 This repository and corresponding NPM package are deprecated in favor of [**mkdirp-bluebird**](https://www.npmjs.com/package/mkdirp-bluebird).
 


### PR DESCRIPTION
Hello, I would like to offer you to take part in this open source, github-based freshdesk-project: https://github.com/maxkoryukov/mkdirp-bluebird . I'm sure, this project could be a good alternative for your project.
 
So, if you are not going to maintain **your** project in the future:

1. Merge this PR to your repository
1. Publish your old package on NPM (to publish the new `README.md` on NPM)
    ```shell
    npm publish
    ```
1. Deprecate your old NPM package, with this command:
    ```shell
    npm deprecate bluebird-mkdirp "Please, use this package: mkdirp-bluebird"
    ```

**Don't unpublish** your package, it is enough to deprecate it :+1: 

### Checklist

* [ ] merge PR
* [ ] publish on NPM
* [ ] deprecate on NPM

PS: this PR is a part of maxkoryukov/mkdirp-bluebird#2